### PR TITLE
Optional parameter to set the folder path for .next

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,10 @@ if (typeof window !== "undefined") {
 /**
  *
  * @param additionalRoutes {array} - accepts an array of any additional routes
+ * @param dotNextDirPath {string} - (optional) the path where the .next folder lives
  * @returns {*[]}
  */
-module.exports.getRouteManifest = function getRouteManifest(additionalRoutes = []) {
+module.exports.getRouteManifest = function getRouteManifest(additionalRoutes = [], dotNextDirPath = "/") {
     if (typeof window !== "undefined") {
         additionalRoutes.forEach(function(page) {
             if (!knownRoutes.includes(page)) {
@@ -57,6 +58,8 @@ module.exports.getRouteManifest = function getRouteManifest(additionalRoutes = [
             pageManifest = path.join(__dirname, "../pages-manifest.json");
         } else if (fs.existsSync(path.join(process.cwd(), ".next/server", "pages-manifest.json"))) {
             pageManifest = path.join(process.cwd(), ".next/server", "pages-manifest.json");
+        } else if (fs.existsSync(path.join(dotNextDirPath, ".next/server", "pages-manifest.json"))) {
+            pageManifest = path.join(dotNextDirPath, ".next/server", "pages-manifest.json");
         }
 
         if (fs.existsSync(path.join(__dirname, "routes-manifest.json"))) {
@@ -65,6 +68,8 @@ module.exports.getRouteManifest = function getRouteManifest(additionalRoutes = [
           routeManifest = path.join(__dirname, "../routes-manifest.json");
         } else if (fs.existsSync(path.join(process.cwd(), ".next", "routes-manifest.json"))) {
           routeManifest = path.join(process.cwd(), ".next", "routes-manifest.json");
+        } else if (fs.existsSync(path.join(dotNextDirPath, ".next", "routes-manifest.json"))) {
+            routeManifest = path.join(dotNextDirPath, ".next", "routes-manifest.json");
         }
 
         if(pageManifest) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-known-route",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Check if a url is a known route to a next.js application ahead of time",
   "main": "index.js",
   "repository": "git@github.com:ScriptedAlchemy/next-known-route.git",


### PR DESCRIPTION
**Issue**
When trying to evaluate `getRoutesManifest()` server-side, it will evaluate to an empty array if the `.next` folder is not in the expected path.

There's no convenient global/environment variable that Next.js provides to indicate the filesystem path for the `.next` folder.

**PR Description**
The location of the build files at runtime varies by environment.
An optional parameter has been added to `getRouteManifest()`  which identifies the location for where the `.next` folder is located.

It's usage will be like so:
`getRouteManifest([], "/path/to/my/dotnextdir/")`
