### PR TITLE
Prettier and i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ typings/
 .cache
 
 # Next.js build output
-.next
 
 # Nuxt.js build / generate output
 .nuxt

--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ const {
 const {
   getRouteMatcher,
 } = require("next/dist/shared/lib/router/utils/route-matcher");
-const { generateRegexRoutesManifest } = require("./utils/generate-regex-routes-manifest");
+const {
+  generateRegexRoutesManifest,
+} = require("./utils/generate-regex-routes-manifest");
 
 let knownRoutes = [];
 if (typeof window !== "undefined") {
@@ -17,10 +19,17 @@ if (typeof window !== "undefined") {
   if (NextRouter.ready) {
     NextRouter.ready(function () {
       try {
-        NextRouter.router.pageLoader.getPageList().then(function (pageList) {
+        const { pageLoader, locales } = NextRouter.router;
+
+        pageLoader.getPageList().then(function (pageList) {
           pageList.forEach(function (page) {
             if (!knownRoutes.includes(page)) {
               knownRoutes.push(page);
+              if (Array.isArray(locales))
+                locales.forEach((locale) => {
+                  if (!page.startsWith("/.."))
+                    knownRoutes.push(`/${locale}${page}`);
+                });
             }
           });
         });

--- a/index.js
+++ b/index.js
@@ -1,29 +1,34 @@
 const NextRouter = require("next/router");
-const { getRouteRegex } = require("next/dist/shared/lib/router/utils/route-regex");
-const { getRouteMatcher } = require("next/dist/shared/lib/router/utils/route-matcher");
+const {
+  getRouteRegex,
+} = require("next/dist/shared/lib/router/utils/route-regex");
+const {
+  getRouteMatcher,
+} = require("next/dist/shared/lib/router/utils/route-matcher");
+const { generateRegexRoutesManifest } = require("./utils/generate-regex-routes-manifest");
+
 let knownRoutes = [];
 if (typeof window !== "undefined") {
-    try {
-        knownRoutes = window.__NEXT_DATA__.props.knownRoutes || window.__NEXT_DATA__.props.layoutProps.knownRoutes;
-    } catch (e) {
-
-    }
-    if (NextRouter.ready) {
-
-        NextRouter.ready(function () {
-            try {
-                NextRouter.router.pageLoader.getPageList().then(function (pageList) {
-                    pageList.forEach(function (page) {
-                        if (!knownRoutes.includes(page)) {
-                            knownRoutes.push(page);
-                        }
-                    });
-                });
-            } catch (e) {
-                console.error(e);
+  try {
+    knownRoutes =
+      window.__NEXT_DATA__.props.knownRoutes ||
+      window.__NEXT_DATA__.props.layoutProps.knownRoutes;
+  } catch (e) {}
+  if (NextRouter.ready) {
+    NextRouter.ready(function () {
+      try {
+        NextRouter.router.pageLoader.getPageList().then(function (pageList) {
+          pageList.forEach(function (page) {
+            if (!knownRoutes.includes(page)) {
+              knownRoutes.push(page);
             }
+          });
         });
-    }
+      } catch (e) {
+        console.error(e);
+      }
+    });
+  }
 }
 /**
  *
@@ -31,86 +36,117 @@ if (typeof window !== "undefined") {
  * @param dotNextDirPath {string} - (optional) the path where the .next folder lives
  * @returns {*[]}
  */
-module.exports.getRouteManifest = function getRouteManifest(additionalRoutes = [], dotNextDirPath = "/") {
-    if (typeof window !== "undefined") {
-        additionalRoutes.forEach(function(page) {
-            if (!knownRoutes.includes(page)) {
-                knownRoutes.push(page);
-            }
-        });
-    } else if(!process.browser) {
-        const path = require("path");
-        const fs = require('fs');
-        let requireFunc;
-        if (typeof __non_webpack_require__ === "undefined") {
-            requireFunc = require;
-        } else {
-            requireFunc = __non_webpack_require__;
-        }
-
-        let serverRoutes = [];
-        let configuredRoutes = []
-        let pageManifest;
-        let routeManifest
-        if (fs.existsSync(path.join(__dirname, "pages-manifest.json"))) {
-            pageManifest = path.join(__dirname, "pages-manifest.json");
-        } else if (fs.existsSync(path.join(__dirname, "../pages-manifest.json"))) {
-            pageManifest = path.join(__dirname, "../pages-manifest.json");
-        } else if (fs.existsSync(path.join(process.cwd(), ".next/server", "pages-manifest.json"))) {
-            pageManifest = path.join(process.cwd(), ".next/server", "pages-manifest.json");
-        } else if (fs.existsSync(path.join(dotNextDirPath, ".next/server", "pages-manifest.json"))) {
-            pageManifest = path.join(dotNextDirPath, ".next/server", "pages-manifest.json");
-        }
-
-        if (fs.existsSync(path.join(__dirname, "routes-manifest.json"))) {
-          routeManifest = path.join(__dirname, "routes-manifest.json");
-        } else if (fs.existsSync(path.join(__dirname, "../routes-manifest.json"))) {
-          routeManifest = path.join(__dirname, "../routes-manifest.json");
-        } else if (fs.existsSync(path.join(process.cwd(), ".next", "routes-manifest.json"))) {
-          routeManifest = path.join(process.cwd(), ".next", "routes-manifest.json");
-        } else if (fs.existsSync(path.join(dotNextDirPath, ".next", "routes-manifest.json"))) {
-            routeManifest = path.join(dotNextDirPath, ".next", "routes-manifest.json");
-        }
-
-        if(pageManifest) {
-            try {
-                serverRoutes = Object.keys(requireFunc(pageManifest));
-            } catch (e) {
-                console.error(e);
-            }
-        }
-        if(routeManifest) {
-            try {
-                var configdRoutes = requireFunc(routeManifest);
-                configuredRoutes = [].concat(configdRoutes.dynamicRoutes, configdRoutes.staticRoutes, configdRoutes.rewrites).filter(function(r){return r}).map(function (route) {
-                    return {regex: route.regex}
-                })
-            } catch(e) {
-                console.error(e)
-            }
-        }
-        knownRoutes = Array.from(new Set([].concat(serverRoutes, additionalRoutes, configuredRoutes)));
+module.exports.getRouteManifest = function getRouteManifest(
+  additionalRoutes = [],
+  dotNextDirPath = "/"
+) {
+  if (typeof window !== "undefined") {
+    additionalRoutes.forEach(function (page) {
+      if (!knownRoutes.includes(page)) {
+        knownRoutes.push(page);
+      }
+    });
+  } else if (!process.browser) {
+    const path = require("path");
+    const fs = require("fs");
+    let requireFunc;
+    if (typeof __non_webpack_require__ === "undefined") {
+      requireFunc = require;
+    } else {
+      requireFunc = __non_webpack_require__;
     }
 
-    return knownRoutes;
+    let serverRoutes = [];
+    let routeManifestRegexRoutes = [];
+    let pageManifest;
+    let routeManifest;
+    if (fs.existsSync(path.join(__dirname, "pages-manifest.json"))) {
+      pageManifest = path.join(__dirname, "pages-manifest.json");
+    } else if (fs.existsSync(path.join(__dirname, "../pages-manifest.json"))) {
+      pageManifest = path.join(__dirname, "../pages-manifest.json");
+    } else if (
+      fs.existsSync(
+        path.join(process.cwd(), ".next/server", "pages-manifest.json")
+      )
+    ) {
+      pageManifest = path.join(
+        process.cwd(),
+        ".next/server",
+        "pages-manifest.json"
+      );
+    } else if (
+      fs.existsSync(
+        path.join(dotNextDirPath, ".next/server", "pages-manifest.json")
+      )
+    ) {
+      pageManifest = path.join(
+        dotNextDirPath,
+        ".next/server",
+        "pages-manifest.json"
+      );
+    }
+
+    if (fs.existsSync(path.join(__dirname, "routes-manifest.json"))) {
+      routeManifest = path.join(__dirname, "routes-manifest.json");
+    } else if (fs.existsSync(path.join(__dirname, "../routes-manifest.json"))) {
+      routeManifest = path.join(__dirname, "../routes-manifest.json");
+    } else if (
+      fs.existsSync(path.join(process.cwd(), ".next", "routes-manifest.json"))
+    ) {
+      routeManifest = path.join(process.cwd(), ".next", "routes-manifest.json");
+    } else if (
+      fs.existsSync(path.join(dotNextDirPath, ".next", "routes-manifest.json"))
+    ) {
+      routeManifest = path.join(
+        dotNextDirPath,
+        ".next",
+        "routes-manifest.json"
+      );
+    }
+
+    if (pageManifest) {
+      try {
+        serverRoutes = Object.keys(requireFunc(pageManifest));
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    if (routeManifest) {
+      try {
+        routeManifestRegexRoutes = generateRegexRoutesManifest(
+          requireFunc(routeManifest)
+        );
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    knownRoutes = Array.from(
+      new Set(
+        [].concat(serverRoutes, additionalRoutes, routeManifestRegexRoutes)
+      )
+    );
+  }
+
+  return knownRoutes;
 };
+
 /**
  * Checks URL against known page routes
  * @param url
  * @returns {boolean}
  */
 module.exports.isKnownRoute = function isKnownRoute(url) {
-    return knownRoutes.some(function(routeExp) {
-        if(typeof routeExp === 'string') {
-            var routeRegex = getRouteRegex(routeExp);
-            var routeMatcher = getRouteMatcher(routeRegex);
-            return routeMatcher(url);
-        }
+  return knownRoutes.some(function (routeExp) {
+    if (typeof routeExp === "string") {
+      var routeRegex = getRouteRegex(routeExp);
+      var routeMatcher = getRouteMatcher(routeRegex);
+      return routeMatcher(url);
+    }
 
-        if(routeExp.regex) {
-            return new RegExp(routeExp.regex).test(url)
-        }
+    if (routeExp.regex) {
+      return new RegExp(routeExp.regex).test(url);
+    }
 
-        return false
-    });
+    return false;
+  });
 };

--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,4 @@
-const { getRouteManifest, isKnownRoute } = require('../');
+const { getRouteManifest, isKnownRoute } = require('./');
 const nextDirPath = `${process.cwd()}/mocks`;
 
 describe('getRouteManifest', () => {

--- a/mocks/.next/routes-manifest.json
+++ b/mocks/.next/routes-manifest.json
@@ -1,0 +1,56 @@
+{
+  "version": 3,
+  "pages404": true,
+  "basePath": "",
+  "redirects": [
+    {
+      "source": "/:path+/",
+      "destination": "/:path+",
+      "locale": false,
+      "internal": true,
+      "statusCode": 308,
+      "regex": "^(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))/$"
+    }
+  ],
+  "headers": [],
+  "dynamicRoutes": [
+    {
+      "page": "/blog/[...slug]",
+      "regex": "^/blog/(.+?)(?:/)?$",
+      "routeKeys": { "nxtPslug": "nxtPslug" },
+      "namedRegex": "^/blog/(?<nxtPslug>.+?)(?:/)?$"
+    }
+  ],
+  "staticRoutes": [
+    {
+      "page": "/",
+      "regex": "^/(?:/)?$",
+      "routeKeys": {},
+      "namedRegex": "^/(?:/)?$"
+    },
+    {
+      "page": "/about",
+      "regex": "^/about(?:/)?$",
+      "routeKeys": {},
+      "namedRegex": "^/about(?:/)?$"
+    }
+  ],
+  "dataRoutes": [],
+  "i18n": {
+    "locales": ["en-us", "en-ca", "fr-ca"],
+    "defaultLocale": "en-us",
+    "localeDetection": false
+  },
+  "rsc": {
+    "header": "RSC",
+    "varyHeader": "RSC, Next-Router-State-Tree, Next-Router-Prefetch",
+    "contentTypeHeader": "text/x-component"
+  },
+  "rewrites": [
+    {
+      "source": "/:nextInternalLocale(en\\-us|en\\-ca|fr\\-ca)/(help|aider)/:wildcard*",
+      "destination": "/:nextInternalLocale/about/:wildcard*",
+      "regex": "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(help|aider))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$"
+    }
+  ]
+}

--- a/mocks/index.test.js
+++ b/mocks/index.test.js
@@ -1,0 +1,89 @@
+const { getRouteManifest, isKnownRoute } = require('../');
+const nextDirPath = `${process.cwd()}/mocks`;
+
+describe('getRouteManifest', () => {
+  beforeAll(() => {
+    getRouteManifest([], nextDirPath);
+  });
+
+  test('should return an array of known routes', () => {
+    const additionalRoutes = [];
+    const routes = getRouteManifest(additionalRoutes, nextDirPath);
+    expect(Array.isArray(routes)).toBe(true);
+    expect(routes.length).toBeGreaterThan(1);
+  });
+
+  test('should include additional routes passed in as an argument', () => {
+    const additionalRoutes = ['/test-route-1', '/test-route-2'];
+    const routes = getRouteManifest(additionalRoutes);
+    expect(routes).toContain(additionalRoutes[0]);
+    expect(routes).toContain(additionalRoutes[1]);
+  });
+
+  test('should filter out duplicate routes', () => {
+    const additionalRoutes = ['/test-route-1', '/test-route-1', '/test-route-2'];
+    const routes = getRouteManifest(additionalRoutes);
+    expect(routes.filter(route => route === additionalRoutes[0]).length).toBe(1);
+    expect(routes.filter(route => route === additionalRoutes[1]).length).toBe(1);
+  });
+
+  test('should handle invalid input', () => {
+    const routes = getRouteManifest(null, '/invalid/path');
+    expect(Array.isArray(routes)).toBe(true);
+    expect(routes.length).toBe(1);
+    expect(routes[0]).toBe(null);
+  });
+});
+
+describe('isKnownRoute', () => {
+  beforeAll(() => {
+    getRouteManifest([], nextDirPath);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should return true for static routes', () => {
+    expect(isKnownRoute('/')).toBe(true);
+    expect(isKnownRoute('/about')).toBe(true);
+    expect(isKnownRoute('/en-ca')).toBe(true);
+    expect(isKnownRoute('/en-ca/')).toBe(true)
+    expect(isKnownRoute('/en-us')).toBe(true);
+    expect(isKnownRoute('/en-us/')).toBe(true);
+    expect(isKnownRoute('/fr-ca')).toBe(true);
+    expect(isKnownRoute('/fr-ca/')).toBe(true);
+    expect(isKnownRoute('/en-ca/about')).toBe(true);
+    expect(isKnownRoute('/en-ca/about/')).toBe(true);
+  });
+
+  test('should return true for dynamic routes', () => {
+    expect(isKnownRoute('/blog/a-slug')).toBe(true);
+    expect(isKnownRoute('/en-ca/blog/a-slug')).toBe(true);
+    expect(isKnownRoute('/en-us/blog/a-slug')).toBe(true);
+    expect(isKnownRoute('/fr-ca/blog/a-slug')).toBe(true);
+
+    expect(isKnownRoute('/blog/a-slug/b-slug')).toBe(true);
+    expect(isKnownRoute('/fr-ca/blog/a-slug/b-slug')).toBe(true);
+  });
+
+  test('should return false for unknown static routes', () => {
+    expect(isKnownRoute('/unknown-route')).toBe(false);
+    expect(isKnownRoute('/en-ca/unknown-route')).toBe(false);
+    expect(isKnownRoute('/en-ca/unknown-route/about')).toBe(false);
+    expect(isKnownRoute('/about/slug')).toBe(false);
+    expect(isKnownRoute('/en-ca/about/slug')).toBe(false);
+  });
+
+  test('should return false for routes without leading slashes', () => {
+    expect(isKnownRoute('unknown-route')).toBe(false);
+    expect(isKnownRoute('blog')).toBe(false);
+    expect(isKnownRoute('en-ca')).toBe(false);
+    expect(isKnownRoute('en-ca/blog')).toBe(false);
+  });
+
+  test('should handle invalid input', () => {
+    expect(isKnownRoute(null)).toBe(false);
+    expect(isKnownRoute(undefined)).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,11 +3,20 @@
   "version": "2.1.2",
   "description": "Check if a url is a known route to a next.js application ahead of time",
   "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "test:debug": "node --inspect=127.0.0.1:9229 ./node_modules/.bin/jest --watch"
+  },
   "repository": "git@github.com:ScriptedAlchemy/next-known-route.git",
   "author": "ScriptedAlchemy <zackary.l.jackson@gmail.com>",
   "license": "MIT",
   "private": false,
   "peerDependencies": {
     "next": "^12.2"
+  },
+  "devDependencies": {
+    "jest": "^29.5.0",
+    "next": "^12.2",
+    "react": "^18.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-known-route",
-  "version": "2.1.2",
+  "version": "2.2.0-rc.1",
   "description": "Check if a url is a known route to a next.js application ahead of time",
   "main": "index.js",
   "scripts": {

--- a/utils/generate-regex-routes-manifest.js
+++ b/utils/generate-regex-routes-manifest.js
@@ -1,0 +1,82 @@
+/**
+ *
+ * @typedef {import("./interfaces/routes-manifest.interface").RoutesManifest} RoutesManifest
+ */
+
+/**
+ * Checks URL against known page routes
+ * @param {RoutesManifest} routesManifest
+ */
+const generateRegexRoutesManifest = (routesManifest) => {
+  const baseRoutesRegex = generateBaseRoutes(routesManifest);
+  const i18nRoutesRegex = generateI18nRoutes(routesManifest);
+
+  return [...baseRoutesRegex, ...i18nRoutesRegex];
+};
+
+/**
+ *
+ * @param {RoutesManifest} routesManifest
+ */
+const generateBaseRoutes = (routesManifest) => {
+  const configuredRoutes = [
+    ...routesManifest.dynamicRoutes,
+    ...routesManifest.staticRoutes,
+    ...routesManifest.rewrites,
+  ];
+
+  return configuredRoutes.map(function (route) {
+    return { regex: route.regex };
+  });
+};
+
+/**
+ * @param {string} regexString
+ * @param {Array<string>} locales
+ * @returns {string}
+ */
+const buildI18nRegex = (regexString, locales) => {
+  // Remove the leading caret from the regexString
+  const baseRouteRegex = RegExp(RegExp(regexString).source.replace(/^\^/, ""));
+
+  // Build a regex that matches any of the supported locales
+  const leadingI18nPathsRegex = RegExp(
+    /(?:\/(?:pipeDelimitedLocales))/.source.replace(
+      "pipeDelimitedLocales",
+      locales.join("|")
+    )
+  );
+
+  // Build a regex that matches any of the supported locales followed by the base route regex
+  const i18nRegex = RegExp(
+    `^(?:${leadingI18nPathsRegex.source})${baseRouteRegex.source}`
+  );
+
+  return i18nRegex.source;
+};
+
+/**
+ *
+ * @param {RoutesManifest} routesManifest
+ */
+const generateI18nRoutes = (routesManifest) => {
+  if (routesManifest?.i18n?.locales?.length > 0) {
+    const configuredRoutes = [
+      ...routesManifest.dynamicRoutes,
+      ...routesManifest.staticRoutes,
+    ];
+    const locales = routesManifest.i18n.locales;
+
+    return (
+      configuredRoutes
+        .map((route) => {
+          return { regex: buildI18nRegex(route.regex, locales) };
+        }).concat(locales.map((locale) => {
+          return { regex: `^\/${locale}$` };
+        }))
+    );
+  }
+  return [];
+};
+
+module.exports = { generateRegexRoutesManifest };

--- a/utils/generate-regex-routes-manifest.js
+++ b/utils/generate-regex-routes-manifest.js
@@ -20,9 +20,9 @@ const generateRegexRoutesManifest = (routesManifest) => {
  */
 const generateBaseRoutes = (routesManifest) => {
   const configuredRoutes = [
-    ...routesManifest.dynamicRoutes,
-    ...routesManifest.staticRoutes,
-    ...routesManifest.rewrites,
+    ...(routesManifest?.dynamicRoutes || []),
+    ...(routesManifest?.staticRoutes || []),
+    ...(routesManifest?.rewrites || []),
   ];
 
   return configuredRoutes.map(function (route) {
@@ -62,19 +62,20 @@ const buildI18nRegex = (regexString, locales) => {
 const generateI18nRoutes = (routesManifest) => {
   if (routesManifest?.i18n?.locales?.length > 0) {
     const configuredRoutes = [
-      ...routesManifest.dynamicRoutes,
-      ...routesManifest.staticRoutes,
+      ...(routesManifest?.dynamicRoutes || []),
+      ...(routesManifest?.staticRoutes || []),
     ];
     const locales = routesManifest.i18n.locales;
 
-    return (
-      configuredRoutes
-        .map((route) => {
-          return { regex: buildI18nRegex(route.regex, locales) };
-        }).concat(locales.map((locale) => {
+    return configuredRoutes
+      .map((route) => {
+        return { regex: buildI18nRegex(route.regex, locales) };
+      })
+      .concat(
+        locales.map((locale) => {
           return { regex: `^\/${locale}$` };
-        }))
-    );
+        })
+      );
   }
   return [];
 };

--- a/utils/generate-regex-routes-manifest.test.js
+++ b/utils/generate-regex-routes-manifest.test.js
@@ -1,0 +1,83 @@
+const {
+  generateRegexRoutesManifest,
+} = require("./generate-regex-routes-manifest");
+
+const routesManifest = {
+  rewrites: [
+    {
+      regex:
+        "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(help|aider))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
+    },
+  ],
+  staticRoutes: [
+    { page: "home", regex: "^/$", routeKeys: {}, namedRegex: "" },
+    { page: "about", regex: "^/about$", routeKeys: {}, namedRegex: "" },
+  ],
+};
+
+const routesManifestI18n = {
+  rewrites: [
+    {
+      regex:
+        "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(help|aider))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
+    },
+  ],
+  staticRoutes: [
+    { page: "home", regex: "^/$", routeKeys: {}, namedRegex: "" },
+    { page: "about", regex: "^/about$", routeKeys: {}, namedRegex: "" },
+  ],
+  i18n: {
+    locales: ["en-US", "es-MX"],
+    defaultLocale: "en-US",
+    localeDetection: false,
+  },
+};
+
+describe("generateRegexRoutesManifest", () => {
+  test("returns an array of regex objects", () => {
+    const regexRoutes = generateRegexRoutesManifest(routesManifest);
+    expect(regexRoutes).toEqual(expect.any(Array));
+    regexRoutes.forEach((route) => {
+      expect(route).toEqual(
+        expect.objectContaining({
+          regex: expect.any(String),
+        })
+      );
+    });
+  });
+
+  test("generates base routes", () => {
+    const regexRoutes = generateRegexRoutesManifest(routesManifest);
+    expect(regexRoutes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ regex: "^/$" }),
+        expect.objectContaining({ regex: "^/about$" }),
+      ])
+    );
+  });
+
+  test("generates i18n routes", () => {
+    const regexRoutes = generateRegexRoutesManifest(routesManifestI18n);
+    expect(regexRoutes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ regex: "^(?:(?:\\/(?:en-US|es-MX)))\\/$" }),
+        expect.objectContaining({
+          regex: "^(?:(?:\\/(?:en-US|es-MX)))\\/about$",
+        }),
+        expect.objectContaining({ regex: "^/en-US$" }),
+        expect.objectContaining({ regex: "^/es-MX$" }),
+      ])
+    );
+  });
+
+  test("should not fail if manifest is not present", () => {    
+    const isNull = generateRegexRoutesManifest(null);
+    const isUndefined = generateRegexRoutesManifest(undefined);
+    const isString = generateRegexRoutesManifest("i-am-a-string");
+
+
+    expect(isNull).toStrictEqual([]);
+    expect(isUndefined).toStrictEqual([]);
+    expect(isString).toStrictEqual([]);
+  });
+});

--- a/utils/interfaces/routes-manifest.interface.ts
+++ b/utils/interfaces/routes-manifest.interface.ts
@@ -1,0 +1,49 @@
+export interface Redirect {
+  source: string;
+  destination: string;
+  locale: boolean;
+  internal: boolean;
+  statusCode: number;
+  regex: string;
+}
+
+export interface Route {
+  page: string;
+  regex: string;
+  routeKeys: {
+    [key: string]: string;
+  };
+  namedRegex: string;
+}
+
+export interface I18n {
+  locales: string[];
+  defaultLocale: string;
+  localeDetection: boolean;
+}
+
+export interface Rsc {
+  header: string;
+  varyHeader: string;
+  contentTypeHeader: string;
+}
+
+export interface Rewrite {
+  source: string;
+  destination: string;
+  regex: string;
+}
+
+export interface RoutesManifest {
+  version: number;
+  pages404: boolean;
+  basePath: string;
+  redirects: Redirect[];
+  headers: any[]; // type can be updated once structure is known
+  dynamicRoutes: Route[];
+  staticRoutes: Route[];
+  dataRoutes: any[]; // type can be updated once structure is known
+  i18n: I18n;
+  rsc: Rsc;
+  rewrites: Rewrite[];
+}


### PR DESCRIPTION
### Problem Statement
When a Next app enables i18n, the sub-paths aren't recognized by `isKnownRoute()`.
For example:
- `/about` returns `true`
- `/en-ca/about` returns `false`
- `/en-us/about` returns `false`

### PR Description
SSR i18n
- `getRouteManifest()` now uses the i18n property included in `routes-manifest.json` to return regular expressions (regex) that matches i18n paths

Client-side i18n
- The initial load that utilizes `NextRouter.router` to iterate over the list of pages from `pageLoader.getPageList()` will now do an additional iteration of `NextRouter.router.locales` to additionally add relative i18n paths.

Prettier
- Applied code formatting