### PR TITLE
Bump to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-known-route",
-  "version": "2.2.0-rc.1",
+  "version": "2.2.0",
   "description": "Check if a url is a known route to a next.js application ahead of time",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Description**
The version 2.2.0-rc.1 has been tested by consumers and has received QA sign-off.

Ready for 2.2.0 release.

**Release Notes**
- i18n sub-paths are now supported