### PR TITLE
Add support to parse rewrite as an object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-known-route",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Check if a url is a known route to a next.js application ahead of time",
   "main": "index.js",
   "scripts": {

--- a/utils/generate-regex-routes-manifest.js
+++ b/utils/generate-regex-routes-manifest.js
@@ -22,7 +22,15 @@ const generateBaseRoutes = (routesManifest) => {
   const configuredRoutes = [
     ...(routesManifest?.dynamicRoutes || []),
     ...(routesManifest?.staticRoutes || []),
-    ...(routesManifest?.rewrites || []),
+    ...(Array.isArray(routesManifest?.rewrites)
+       /* The rewrites property is an array when the parent caller's requireFunc uses Node.js' native require(). */
+      ? routesManifest?.rewrites
+      /* The rewrites property is an object when the parent caller's requireFunc uses __non_webpack_require__(). */
+      : [
+          ...(routesManifest?.rewrites?.beforeFiles || []),
+          ...(routesManifest?.rewrites?.afterFiles || []),
+          ...(routesManifest?.rewrites?.fallback || []),
+        ] || []),
   ];
 
   return configuredRoutes.map(function (route) {

--- a/utils/generate-regex-routes-manifest.js
+++ b/utils/generate-regex-routes-manifest.js
@@ -23,14 +23,14 @@ const generateBaseRoutes = (routesManifest) => {
     ...(routesManifest?.dynamicRoutes || []),
     ...(routesManifest?.staticRoutes || []),
     ...(Array.isArray(routesManifest?.rewrites)
-       /* The rewrites property is an array when the parent caller's requireFunc uses Node.js' native require(). */
-      ? routesManifest?.rewrites
-      /* The rewrites property is an object when the parent caller's requireFunc uses __non_webpack_require__(). */
-      : [
+      ? /* The rewrites property is an array when the parent caller's requireFunc uses Node.js' native require(). */
+        routesManifest?.rewrites
+      : /* The rewrites property is an object when the parent caller's requireFunc uses __non_webpack_require__(). */
+        [
           ...(routesManifest?.rewrites?.beforeFiles || []),
           ...(routesManifest?.rewrites?.afterFiles || []),
           ...(routesManifest?.rewrites?.fallback || []),
-        ] || []),
+        ]),
   ];
 
   return configuredRoutes.map(function (route) {

--- a/utils/generate-regex-routes-manifest.test.js
+++ b/utils/generate-regex-routes-manifest.test.js
@@ -2,36 +2,41 @@ const {
   generateRegexRoutesManifest,
 } = require("./generate-regex-routes-manifest");
 
-const routesManifest = {
-  rewrites: [
-    {
-      regex:
-        "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(help|aider))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
-    },
-  ],
-  staticRoutes: [
-    { page: "home", regex: "^/$", routeKeys: {}, namedRegex: "" },
-    { page: "about", regex: "^/about$", routeKeys: {}, namedRegex: "" },
-  ],
-};
+let routesManifest;
+let routesManifestI18n;
 
-const routesManifestI18n = {
-  rewrites: [
-    {
-      regex:
-        "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(help|aider))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
+beforeEach(() => {
+  routesManifest = {
+    rewrites: [
+      {
+        regex:
+          "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(help|aider))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
+      },
+    ],
+    staticRoutes: [
+      { page: "home", regex: "^/$", routeKeys: {}, namedRegex: "" },
+      { page: "about", regex: "^/about$", routeKeys: {}, namedRegex: "" },
+    ],
+  };
+
+  routesManifestI18n = {
+    rewrites: [
+      {
+        regex:
+          "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(help|aider))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
+      },
+    ],
+    staticRoutes: [
+      { page: "home", regex: "^/$", routeKeys: {}, namedRegex: "" },
+      { page: "about", regex: "^/about$", routeKeys: {}, namedRegex: "" },
+    ],
+    i18n: {
+      locales: ["en-US", "es-MX"],
+      defaultLocale: "en-US",
+      localeDetection: false,
     },
-  ],
-  staticRoutes: [
-    { page: "home", regex: "^/$", routeKeys: {}, namedRegex: "" },
-    { page: "about", regex: "^/about$", routeKeys: {}, namedRegex: "" },
-  ],
-  i18n: {
-    locales: ["en-US", "es-MX"],
-    defaultLocale: "en-US",
-    localeDetection: false,
-  },
-};
+  };
+});
 
 describe("generateRegexRoutesManifest", () => {
   test("returns an array of regex objects", () => {
@@ -70,11 +75,39 @@ describe("generateRegexRoutesManifest", () => {
     );
   });
 
-  test("should not fail if manifest is not present", () => {    
+  test("generates routes when routes-manifest.json has a rewrites object instead of an array", () => {
+    routesManifest.rewrites = {
+      beforeFiles: [],
+      afterFiles: [
+        {
+          source:
+            "/:nextInternalLocale(en\\-us|en\\-ca|fr\\-ca)/(help|aider)/:wildcard*",
+          destination: "/:nextInternalLocale/about/:wildcard*",
+          regex:
+            "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(mytest|mytest2))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
+        },
+      ],
+      fallback: [],
+    };
+
+    const regexRoutes = generateRegexRoutesManifest(routesManifest);
+
+    expect(regexRoutes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({"regex": "^/$"}),
+        expect.objectContaining({"regex": "^/about$"}),
+        expect.objectContaining({
+          regex:
+            "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(mytest|mytest2))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
+        }),
+      ])
+    );
+  });
+
+  test("should not fail if manifest is not present", () => {
     const isNull = generateRegexRoutesManifest(null);
     const isUndefined = generateRegexRoutesManifest(undefined);
     const isString = generateRegexRoutesManifest("i-am-a-string");
-
 
     expect(isNull).toStrictEqual([]);
     expect(isUndefined).toStrictEqual([]);


### PR DESCRIPTION
**Description**

When the `routes-manifest.json` is imported using `__non_webpack_require__()`, the `rewrites` property becomes an object with nested properties containing arrays.

Example value of the `rewrites` property as an object:
```javascript
{
  beforeFiles: [],
  afterFiles: [
    {
      source:
        "/:nextInternalLocale(en\\-us|en\\-ca|fr\\-ca)/(help|aider)/:wildcard*",
      destination: "/:nextInternalLocale/about/:wildcard*",
      regex:
        "^(?:/(en\\-us|en\\-ca|fr\\-ca))(?:/(help|aider))(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$",
    },
  ],
  fallback: [],
};
```

This change ensures that both a `rewrites` property provided as an array or object are processed.